### PR TITLE
Update automatic make to use install-clean with spinn-common

### DIFF
--- a/automatic_make.sh
+++ b/automatic_make.sh
@@ -8,6 +8,7 @@ make || exit $?
 cd ..
 cd spinn_common
 make clean
+make install-clean
 make || exit $?
 make install
 cd ..


### PR DESCRIPTION
Updated automatic_make to use the install-clean option in https://github.com/SpiNNakerManchester/spinn_common/pull/25