### PR TITLE
Rat support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.project
 /.pydevproject
+/apache-rat-*

--- a/rat.sh
+++ b/rat.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+dir0=$(dirname $BASH_SOURCE)
+echo $dir0
+op="$1"
+shift
+ratver=0.12
+raturl="http://www.mirrorservice.org/sites/ftp.apache.org//creadur/apache-rat-${ratver}/apache-rat-${ratver}-bin.tar.gz"
+case $op in
+	download)
+		curl --output - "$raturl" 2>/dev/null | (cd $dir0 && tar -zxf -)
+		;;
+	run)
+		java -jar "${dir0}/apache-rat-${ratver}/apache-rat-${ratver}.jar" ${1+"$@"}
+		;;
+	*)
+		echo "unknown op \"$op\": must be download or run" >&2
+		exit 1
+		;;
+esac
+exit $?

--- a/rat.sh
+++ b/rat.sh
@@ -1,16 +1,17 @@
 #!/bin/bash
 dir0=$(dirname $BASH_SOURCE)
-echo $dir0
 op="$1"
 shift
 ratver=0.12
 raturl="http://www.mirrorservice.org/sites/ftp.apache.org//creadur/apache-rat-${ratver}/apache-rat-${ratver}-bin.tar.gz"
+ant=${ANT-ant}
 case $op in
 	download)
 		curl --output - "$raturl" 2>/dev/null | (cd $dir0 && tar -zxf -)
 		;;
 	run)
-		java -jar "${dir0}/apache-rat-${ratver}/apache-rat-${ratver}.jar" ${1+"$@"}
+		# java -jar "${dir0}/apache-rat-${ratver}/apache-rat-${ratver}.jar" ${1+"$@"}
+		eval $ant "-e -q -f $dir0/rat.xml -lib $dir0/apache-rat-$ratver rat"
 		;;
 	*)
 		echo "unknown op \"$op\": must be download or run" >&2

--- a/rat.xml
+++ b/rat.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project name="rat"
+		xmlns:rat="antlib:org.apache.rat.anttasks"
+		xmlns:if="ant:if" xmlns="antlib:org.apache.tools.ant">
+    <target name="rat">
+    	<rat:report reportFile="${user.dir}/RAT_report.txt">
+    		<fileset dir="${user.dir}" defaultexcludes="yes"
+    			excludesfile="${user.dir}/.ratexcludes"
+    			excludes="RAT_report.txt" />
+    	</rat:report>
+    	<fail message="RAT_report.txt not generated">
+    		<condition>
+    			<not>
+	    			<resourcecount count="1">
+	    				<fileset dir="${user.dir}" includes="RAT_report.txt" />
+	    			</resourcecount>
+    			</not>
+    		</condition>
+    	</fail>
+    	<loadfile property="report" srcfile="${user.dir}/RAT_report.txt">
+    		<filterchain>
+    			<tokenfilter>
+    				<filetokenizer />
+	    			<replaceregex
+	    				pattern="\s*Printing headers for text files without a valid license header.*"
+	    				replace="" flags="s" />
+    			</tokenfilter>
+    		</filterchain>
+    	</loadfile>
+		<condition property="problems">
+			<not>
+    			<contains string="${report}"
+    				substring="&#10;0 Unknown Licenses" />
+			</not>
+		</condition>
+    	<echo if:set="problems" message="${report}" />
+    	<fail message="Unknown Licenses found">
+    		<condition>
+    			<not>
+        			<contains string="${report}"
+        				substring="&#10;0 Unknown Licenses" />
+    			</not>
+    		</condition>
+    	</fail>
+    </target>
+</project>

--- a/rat.xml
+++ b/rat.xml
@@ -1,46 +1,44 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project name="rat"
-		xmlns:rat="antlib:org.apache.rat.anttasks"
-		xmlns:if="ant:if" xmlns="antlib:org.apache.tools.ant">
+<project name="rat" xmlns:rat="antlib:org.apache.rat.anttasks"
+        xmlns:if="ant:if" xmlns="antlib:org.apache.tools.ant">
     <target name="rat">
-    	<rat:report reportFile="${user.dir}/RAT_report.txt">
-    		<fileset dir="${user.dir}" defaultexcludes="yes"
-    			excludesfile="${user.dir}/.ratexcludes"
-    			excludes="RAT_report.txt" />
-    	</rat:report>
-    	<fail message="RAT_report.txt not generated">
-    		<condition>
-    			<not>
-	    			<resourcecount count="1">
-	    				<fileset dir="${user.dir}" includes="RAT_report.txt" />
-	    			</resourcecount>
-    			</not>
-    		</condition>
-    	</fail>
-    	<loadfile property="report" srcfile="${user.dir}/RAT_report.txt">
-    		<filterchain>
-    			<tokenfilter>
-    				<filetokenizer />
-	    			<replaceregex
-	    				pattern="\s*Printing headers for text files without a valid license header.*"
-	    				replace="" flags="s" />
-    			</tokenfilter>
-    		</filterchain>
-    	</loadfile>
-		<condition property="problems">
-			<not>
-    			<contains string="${report}"
-    				substring="&#10;0 Unknown Licenses" />
-			</not>
-		</condition>
-    	<echo if:set="problems" message="${report}" />
-    	<fail message="Unknown Licenses found">
-    		<condition>
-    			<not>
-        			<contains string="${report}"
-        				substring="&#10;0 Unknown Licenses" />
-    			</not>
-    		</condition>
-    	</fail>
+        <rat:report reportFile="${user.dir}/RAT_report.txt">
+            <fileset dir="${user.dir}" defaultexcludes="yes"
+                excludesfile="${user.dir}/.ratexcludes"
+                excludes="RAT_report.txt" />
+        </rat:report>
+        <fail message="RAT_report.txt not generated">
+            <condition>
+                <not>
+                    <resourcecount count="1">
+                        <fileset dir="${user.dir}" includes="RAT_report.txt" />
+                    </resourcecount>
+                </not>
+            </condition>
+        </fail>
+        <loadfile property="report" srcfile="${user.dir}/RAT_report.txt">
+            <filterchain>
+                <tokenfilter>
+                    <filetokenizer />
+                    <replaceregex replace="" flags="s"
+                        pattern="\s*Printing headers for text files without a valid license header.*" />
+                </tokenfilter>
+            </filterchain>
+        </loadfile>
+        <condition property="problems">
+            <not>
+                <contains string="${report}"
+                    substring="&#10;0 Unknown Licenses" />
+            </not>
+        </condition>
+        <echo if:set="problems" message="${report}" />
+        <fail message="Unknown Licenses found">
+            <condition>
+                <not>
+                    <contains string="${report}"
+                        substring="&#10;0 Unknown Licenses" />
+                </not>
+            </condition>
+        </fail>
     </target>
 </project>


### PR DESCRIPTION
Rat is a tool for checking for license headers; we already use it for our Java code as part of our quality checks. This makes it so that we can also use it for our Python and C code, taming it so it produces a useful report only when it is of actual value and failing (presumably) the CI build when we haven't sorted out our licenses properly.

Note that there are formal forms for license header comments that _every file_ should support (if the format supports comments at all). We've been very bad at not doing this in the past; this is part of a drive to be much stricter about this going forward.