### PR TITLE
Drop support for python 3.6

### DIFF
--- a/actions/install-matplotlib/requirements.txt
+++ b/actions/install-matplotlib/requirements.txt
@@ -13,9 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-numpy > 1.13, < 1.20; python_version == '3.6'
 numpy > 1.13, < 1.21; python_version == '3.7'
 numpy; python_version >= '3.8'
-matplotlib < 3.4; python_version == '3.6'
 matplotlib < 3.5.99; python_version == '3.7'
 matplotlib; python_version >= '3.8'


### PR DESCRIPTION
Python 3.6 is end of life, so this and subsequent PRs on other repositories remove that, and also switch to using ubuntu-latest everywhere (which required this change, see https://github.com/SpiNNakerManchester/sPyNNaker/issues/1255).