### PR TITLE
Spell checking

### DIFF
--- a/actions/checkout-spinn-deps/action.yml
+++ b/actions/checkout-spinn-deps/action.yml
@@ -14,18 +14,22 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 name: "Check out and install SpiNNaker dependencies"
+description: >
+  Checks out (and optionally installs) SpiNNaker dependencies.
 inputs:
   repositories:
-    description: The list of SpiNNaker dependencies to check out
+    description: >
+      The list of SpiNNaker dependencies to check out. Space-separated
     required: true
   install:
     description: Whether to install the dependency after checking it out
     required: false
-    default: false
+    default: "false"
   preinstall:
-    description: Whether to pre-install the dependencies before running the installer
+    description: >
+      Whether to pre-install the dependencies before running the installer
     required: false
-    default: false
+    default: "false"
   requirements-filename:
     description: The name of the requirements file
     required: false

--- a/actions/configure-spynnaker/action.yml
+++ b/actions/configure-spynnaker/action.yml
@@ -14,7 +14,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 name: "Configure sPyNNaker for Execution"
-description: "Creates a sPyNNaker configuration file."
+description: >
+  Creates a sPyNNaker configuration file.
 inputs:
   board-address:
     description: The IP address of the SpiNNaker board to talk to directly
@@ -23,7 +24,7 @@ inputs:
   version:
     description: What version of SpiNNaker board to talk to
     required: false
-    default: 5
+    default: "5"
   spalloc:
     description: Where the spalloc server is located
     required: false
@@ -31,7 +32,7 @@ inputs:
   port:
     description: What port to contact spalloc on
     required: false
-    default: 22444
+    default: "22444"
   user:
     description: What user name to use for spalloc
     required: false
@@ -39,15 +40,15 @@ inputs:
   virtual:
     description: Whether to use a virtual machine
     required: false
-    default: false
+    default: "false"
   width:
     description: The width of the virtual machine, in chips
     required: false
-    default: 8
+    default: "8"
   height:
     description: The height of the virtual machine, in chips
     required: false
-    default: 8
+    default: "8"
   time_scale_factor:
     description: Time scale factor allows the slowing down of the simulation
     required: false

--- a/actions/install-matplotlib/action.yml
+++ b/actions/install-matplotlib/action.yml
@@ -17,9 +17,12 @@
 # as different versions of matplotlib and python are released.
 
 name: Install matplotlib
+description: >
+  Installs matplotlib in a way that is suitable for running CI workflows
+  against for the purposes of testing.
 inputs:
   back-end: 
-    description: Which rendering engine to use, a python module name
+    description: Which rendering engine to use, a Python module name
     required: false
     default: matplotlib.backends.backend_agg
 runs:

--- a/actions/install-spinn-deps/action.yml
+++ b/actions/install-spinn-deps/action.yml
@@ -14,14 +14,17 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 name: "Check out and install SpiNNaker dependencies"
+description: >
+  Checks out (and optionally installs) SpiNNaker dependencies.
 inputs:
   repositories:
-    description: The list of SpiNNaker dependencies to check out
+    description: >
+      The list of SpiNNaker dependencies to check out. Space-separated
     required: true
   install:
     description: Whether to install the dependency after checking it out
     required: false
-    default: false
+    default: "false"
 runs:
   using: composite
   steps:

--- a/actions/pylint/action.yml
+++ b/actions/pylint/action.yml
@@ -59,27 +59,13 @@ runs:
   using: composite
   steps:
     - name: Build composite dictionary
-      run: |
-        cat ${{ github.action_path }}/default_dict.txt >/tmp/dict.txt
-        if test -r $DICTIONARY; then
-          cat "$DICTIONARY" >>/tmp/dict.txt
-        fi
+      run: source ${{ github.action_path }}/mkdict.bash
       shell: bash
       env:
+        BASE_DICTIONARY: ${{ github.action_path }}/default_dict.txt
         DICTIONARY: ${{ inputs.dictionary }}
     - name: Run pylint
-      run: |
-        if test -n $SPELL_LANG; then
-          pylint --output-format=colorized "--disable=$DISABLE_CATS" \
-            --persistent=no "--jobs=$JOBS" --rcfile=$RC \
-            "--spelling-dict=$SPELL_LANG" --spelling-private-dict-file=/tmp/dict.txt \
-            $PACKAGES || exit $(($? & $FAIL_CODE))
-        else
-          pylint --output-format=colorized "--disable=$DISABLE_CATS" \
-            --persistent=no "--jobs=$JOBS" "--rcfile=$RC" \
-            $PACKAGES || exit $(($? & $FAIL_CODE))
-        fi
-      # Note that there's special conditioning of the return code of pylint
+      run: source ${{ github.action_path }}/run_pylint.bash
       shell: bash
       env:
         PACKAGES: ${{ inputs.package }}

--- a/actions/pylint/action.yml
+++ b/actions/pylint/action.yml
@@ -24,11 +24,11 @@ inputs:
   disable:
     description: The messages/categories to disable
     required: false
-    default: "R,C"
+    default: "R"
   jobs:
     description: The number of Python processes to use
     required: false
-    default: 1
+    default: "1"
   rcfile:
     description: The name of the pylint rc file
     required: false
@@ -36,7 +36,7 @@ inputs:
   exitcheck:
     description: The combined results code to fail on
     required: false
-    default: 35
+    default: "39"
     # Pylint should leave with following status code:
     #  0 if everything went fine
     # 1 if a fatal message was issued
@@ -47,12 +47,22 @@ inputs:
     # 32 on usage error
     # to die on fatal, error or usage the recommended way is
     # exit $(($? & 35))
+  language:
+    description: The (human) language to use for spell checking
+    required: false
+    default: en_GB
+  dictionary:
+    description: The custom dictionary to use for spell checking
+    required: false
+    default: .pylint_dict.txt
 runs:
   using: composite
   steps:
     - run: |
         pylint --output-format=colorized --disable=${{ inputs.disable }} \
           --persistent=no --jobs=${{ inputs.jobs }} --rcfile=${{ inputs.rcfile }} \
+          --spelling-dict=${{ inputs.language }} \
+          --spelling-private-dict-file=${{ inputs.dictionary }} \
           ${{ inputs.package }} || exit $(($? & ${{ inputs.exitcheck }}))
       # Note that there's special conditioning of the return code of pylint
       shell: bash

--- a/actions/pylint/action.yml
+++ b/actions/pylint/action.yml
@@ -59,10 +59,23 @@ runs:
   using: composite
   steps:
     - run: |
-        pylint --output-format=colorized --disable=${{ inputs.disable }} \
-          --persistent=no --jobs=${{ inputs.jobs }} --rcfile=${{ inputs.rcfile }} \
-          --spelling-dict=${{ inputs.language }} \
-          --spelling-private-dict-file=${{ inputs.dictionary }} \
-          ${{ inputs.package }} || exit $(($? & ${{ inputs.exitcheck }}))
+        if test -r $DICTIONARY; then
+          pylint --output-format=colorized "--disable=$DISABLE_CATS" \
+            --persistent=no "--jobs=$JOBS" --rcfile=$RC \
+            "--spelling-dict=$SPELL_LANG" "--spelling-private-dict-file=$DICTIONARY" \
+            $PACKAGES || exit $(($? & $FAIL_CODE))
+        else
+          pylint --output-format=colorized "--disable=$DISABLE_CATS" \
+            --persistent=no "--jobs=$JOBS" "--rcfile=$RC" \
+            $PACKAGES || exit $(($? & $FAIL_CODE))
+        fi
       # Note that there's special conditioning of the return code of pylint
       shell: bash
+      env:
+        PACKAGES: ${{ inputs.package }}
+        DISABLE_CATS: ${{ inputs.disable }}
+        RC: ${{ inputs.rcfile }}
+        JOBS: ${{ inputs.jobs }}
+        SPELL_LANG: ${{ inputs.language }}
+        DICTIONARY: ${{ inputs.dictionary }}
+        FAIL_CODE: ${{ inputs.exitcheck }}

--- a/actions/pylint/action.yml
+++ b/actions/pylint/action.yml
@@ -59,13 +59,14 @@ runs:
   using: composite
   steps:
     - name: Build composite dictionary
-      run: source ${{ github.action_path }}/mkdict.bash
+      run: source $SUPPORT_DIR/mkdict.bash
       shell: bash
       env:
         BASE_DICTIONARY: ${{ github.action_path }}/default_dict.txt
         DICTIONARY: ${{ inputs.dictionary }}
+        SUPPORT_DIR: ${{ github.action_path }}
     - name: Run pylint
-      run: source ${{ github.action_path }}/run_pylint.bash
+      run: source $SUPPORT_DIR/run_pylint.bash
       shell: bash
       env:
         PACKAGES: ${{ inputs.package }}
@@ -74,3 +75,4 @@ runs:
         JOBS: ${{ inputs.jobs }}
         SPELL_LANG: ${{ inputs.language }}
         FAIL_CODE: ${{ inputs.exitcheck }}
+        SUPPORT_DIR: ${{ github.action_path }}

--- a/actions/pylint/action.yml
+++ b/actions/pylint/action.yml
@@ -36,17 +36,21 @@ inputs:
   exitcheck:
     description: The combined results code to fail on
     required: false
-    default: "39"
+    default: "6"  # Action fails on ERROR or WARNING
     # Pylint should leave with following status code:
-    #  0 if everything went fine
-    # 1 if a fatal message was issued
-    # 2 if an error message was issued
-    # 4 if a warning message was issued
-    # 8 if a refactor message was issued
-    # 16 if a convention message was issued
-    # 32 on usage error
+    #    0 if everything went fine
+    #    1 if a fatal message was issued
+    #    2 if an error message was issued
+    #    4 if a warning message was issued
+    #    8 if a refactor message was issued
+    #   16 if a convention message was issued
+    #   32 on usage error
     # to die on fatal, error or usage the recommended way is
-    # exit $(($? & 35))
+    #   exit $(($? & 35))
+    # We handle that internally.
+    #
+    # Also note that we ALWAYS die on Fatal or Usage problems; others are 
+    # selectable.
   language:
     description: The (human) language to use for spell checking
     required: false

--- a/actions/pylint/action.yml
+++ b/actions/pylint/action.yml
@@ -50,7 +50,7 @@ inputs:
   language:
     description: The (human) language to use for spell checking
     required: false
-    default: en_GB
+    default: ""
   dictionary:
     description: The custom dictionary to use for spell checking
     required: false
@@ -58,11 +58,21 @@ inputs:
 runs:
   using: composite
   steps:
-    - run: |
+    - name: Build composite dictionary
+      run: |
+        cat ${{ github.action_path }}/default_dict.txt >/tmp/dict.txt
         if test -r $DICTIONARY; then
+          cat "$DICTIONARY" >>/tmp/dict.txt
+        fi
+      shell: bash
+      env:
+        DICTIONARY: ${{ inputs.dictionary }}
+    - name: Run pylint
+      run: |
+        if test -n $SPELL_LANG; then
           pylint --output-format=colorized "--disable=$DISABLE_CATS" \
             --persistent=no "--jobs=$JOBS" --rcfile=$RC \
-            "--spelling-dict=$SPELL_LANG" "--spelling-private-dict-file=$DICTIONARY" \
+            "--spelling-dict=$SPELL_LANG" --spelling-private-dict-file=/tmp/dict.txt \
             $PACKAGES || exit $(($? & $FAIL_CODE))
         else
           pylint --output-format=colorized "--disable=$DISABLE_CATS" \
@@ -77,5 +87,4 @@ runs:
         RC: ${{ inputs.rcfile }}
         JOBS: ${{ inputs.jobs }}
         SPELL_LANG: ${{ inputs.language }}
-        DICTIONARY: ${{ inputs.dictionary }}
         FAIL_CODE: ${{ inputs.exitcheck }}

--- a/actions/pylint/default_dict.txt
+++ b/actions/pylint/default_dict.txt
@@ -25,6 +25,7 @@ STDP
 SDRAM
 APLX
 DSG
+RNG
 
 # Sphinx keyword
 attr

--- a/actions/pylint/default_dict.txt
+++ b/actions/pylint/default_dict.txt
@@ -27,6 +27,7 @@ bool
 int
 str
 dict
+frozenset
 bytearray
 memoryview
 ndarray

--- a/actions/pylint/default_dict.txt
+++ b/actions/pylint/default_dict.txt
@@ -102,3 +102,4 @@ timestep
 timesteps
 bitfield
 bitfields
+routable

--- a/actions/pylint/default_dict.txt
+++ b/actions/pylint/default_dict.txt
@@ -17,6 +17,14 @@ FEC
 ASB
 sPyNNaker
 DBs
+SCP
+SDP
+BMP
+EIEIO
+STDP
+SDRAM
+APLX
+DSG
 
 # Sphinx keyword
 attr
@@ -51,11 +59,16 @@ classmethod
 classproperty
 getx
 setx
+isinstance
 
 # Python packages
 math
+io
+os
+sys
 datetime
 configparser
+matplotlib
 numpy
 scipy
 testfixtures
@@ -68,9 +81,24 @@ whitespace
 ids
 submessage
 subclassed
+subclassing
 src
 dest
 msg
 spynnaker
 cfg
 etc
+defaultable
+undelayed
+unpartitioned
+unregisters
+unsets
+writable
+datasheet
+microsiemens
+nanoamps
+nanofarads
+timestep
+timesteps
+bitfield
+bitfields

--- a/actions/pylint/default_dict.txt
+++ b/actions/pylint/default_dict.txt
@@ -29,6 +29,7 @@ str
 dict
 bytearray
 memoryview
+ndarray
 traceback
 timedelta
 

--- a/actions/pylint/default_dict.txt
+++ b/actions/pylint/default_dict.txt
@@ -1,0 +1,74 @@
+# Copyright (c) 2023 The University of Manchester
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Our abbreviations/names
+FEC
+ASB
+sPyNNaker
+CFF
+DBs
+LCM
+
+# Sphinx keyword
+py
+rtype
+
+# Python types
+bool
+int
+str
+dict
+bytearray
+memoryview
+traceback
+timedelta
+
+# Python pseudo-types
+iterable
+
+# Python specials
+args
+kwargs
+eval
+setattr
+metaclass
+abstractmethod
+abstractproperty
+classmethod
+classproperty
+getx
+setx
+
+# Python packages
+math
+datetime
+configparser
+numpy
+scipy
+testfixtures
+abc
+zipfile
+
+# Misc
+stdin
+whitespace
+ids
+submessage
+subclassed
+src
+dest
+msg
+spynnaker
+cfg
+etc

--- a/actions/pylint/default_dict.txt
+++ b/actions/pylint/default_dict.txt
@@ -16,9 +16,7 @@
 FEC
 ASB
 sPyNNaker
-CFF
 DBs
-LCM
 
 # Sphinx keyword
 py

--- a/actions/pylint/default_dict.txt
+++ b/actions/pylint/default_dict.txt
@@ -19,6 +19,8 @@ sPyNNaker
 DBs
 
 # Sphinx keyword
+attr
+ivar
 py
 rtype
 

--- a/actions/pylint/mkdict.bash
+++ b/actions/pylint/mkdict.bash
@@ -15,9 +15,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-target=/tmp/dict.txt
+dict=/tmp/dict.txt
 
-cat "$BASE_DICTIONARY" >$target
+cat "$BASE_DICTIONARY" >$dict
 if test -r $DICTIONARY; then
-	cat "$DICTIONARY" >>$target
+	cat "$DICTIONARY" >>$dict
 fi

--- a/actions/pylint/mkdict.bash
+++ b/actions/pylint/mkdict.bash
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Copyright (c) 2023 The University of Manchester
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+target=/tmp/dict.txt
+
+cat "$BASE_DICTIONARY" >$target
+if test -r $DICTIONARY; then
+	cat "$DICTIONARY" >>$target
+fi

--- a/actions/pylint/run_pylint.bash
+++ b/actions/pylint/run_pylint.bash
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Copyright (c) 2020 The University of Manchester
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+if test -n "$SPELL_LANG"; then
+	pylint --output-format=colorized "--disable=$DISABLE_CATS" \
+		--persistent=no "--jobs=$JOBS" --rcfile=$RC \
+		"--spelling-dict=$SPELL_LANG" --spelling-private-dict-file=/tmp/dict.txt \
+		$PACKAGES
+else
+	pylint --output-format=colorized "--disable=$DISABLE_CATS" \
+		--persistent=no "--jobs=$JOBS" "--rcfile=$RC" \
+		$PACKAGES
+fi
+# Note that there's special conditioning of the return code of pylint
+exit $(($? & $FAIL_CODE))

--- a/actions/pylint/run_pylint.bash
+++ b/actions/pylint/run_pylint.bash
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+set +e
 if test -n "$SPELL_LANG"; then
 	pylint --output-format=colorized "--disable=$DISABLE_CATS" \
 		--persistent=no "--jobs=$JOBS" --rcfile=$RC \

--- a/actions/pylint/run_pylint.bash
+++ b/actions/pylint/run_pylint.bash
@@ -15,16 +15,20 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+dict=/tmp/dict.txt
+
 set +e
 if test -n "$SPELL_LANG"; then
 	pylint --output-format=colorized "--disable=$DISABLE_CATS" \
-		--persistent=no "--jobs=$JOBS" --rcfile=$RC \
-		"--spelling-dict=$SPELL_LANG" --spelling-private-dict-file=/tmp/dict.txt \
+		--persistent=no "--jobs=$JOBS" "--rcfile=$RC" \
+		"--spelling-dict=$SPELL_LANG" "--spelling-private-dict-file=$dict" \
 		$PACKAGES
 else
 	pylint --output-format=colorized "--disable=$DISABLE_CATS" \
 		--persistent=no "--jobs=$JOBS" "--rcfile=$RC" \
 		$PACKAGES
 fi
+
 # Note that there's special conditioning of the return code of pylint
-exit $(($? & $FAIL_CODE))
+exit $(( $? & ($FAIL_CODE | 33) ))
+# Fatal (1) and Usage (32) errors are ALWAYS enabled in the bit mask

--- a/actions/pynn-setup/action.yml
+++ b/actions/pynn-setup/action.yml
@@ -14,6 +14,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 name: "Install sPyNNaker into PyNN"
+description: >
+  Installs sPyNNaker into the PyNN package.
+  Evil code! Requires that the PyNN package be somewhere editable.
 runs:
   using: composite
   steps: 

--- a/actions/pytest/action.yml
+++ b/actions/pytest/action.yml
@@ -29,7 +29,7 @@ inputs:
   coverage:
     description: Whether to do coverage
     required: false
-    default: false
+    default: "false"
   cover-packages:
     description: The names of the Python packages to get coverage of.
     required: false
@@ -51,7 +51,7 @@ inputs:
       https://github.com/TheKevJames/coveralls-python/blob/master/docs/usage/configuration.rst
       for details. (tl;dr: coveralls --service=github --finish)
     required: false
-    default: false
+    default: "false"
 runs:
   using: composite
   steps:

--- a/actions/python-tools/action.yml
+++ b/actions/python-tools/action.yml
@@ -39,18 +39,30 @@ inputs:
 runs:
   using: composite
   steps:
+  - name: Dependency preconfigure
+    shell: bash
+    run: |
+      echo "::group::Doing dependency preconfiguration"
+      sudo apt-get update
+      echo "::endgroup::"
   - name: Install spell checker
     shell: bash
     run: |
-      sudo apt-get update
+      echo "::group::Installing spell checker"
       sudo apt-get -o Dpkg::Use-Pty=0 install --fix-missing enchant-2 $SPELL_PACKAGES
+      echo "::endgroup::"
     env:
       SPELL_PACKAGES: ${{ inputs.spell-checker-implementation }}
+  - name: Upgrade Python baseline tooling
+    shell: bash
+    run: |
+      echo "::group::Upgrading Python baseline tooling"
+      python -m pip install --upgrade setuptools wheel
+      python -m pip install pip
+      echo "::endgroup::"
   - name: Install Python tooling
     shell: bash
     run: |
-      python -m pip install --upgrade setuptools wheel
-      python -m pip install pip
       pip install flake8 "pylint $PYLINT_VERSION" pyenchant
       if [ $DO_COVERAGE = "true" ]; then
         pip install "coverage $COVERAGE_VERSION" coveralls

--- a/actions/python-tools/action.yml
+++ b/actions/python-tools/action.yml
@@ -14,6 +14,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 name: "Install Advanced Python Tools"
+description: >
+  Installs tooling to support advanced Python testing.
 inputs:
   pylint-version:
     description: The version of pylint desired
@@ -22,22 +24,37 @@ inputs:
   coverage:
     description: Whether to install tools for coverage checking
     required: false
-    default: true
+    default: "true"
   coverage-version:
     description: The version of coverage desired
     required: false
     default: ">= 4.4, < 5.0"
+  spell-checker-implementation:
+    description: >
+      The packages required for the implementation of the spell checker. These
+      run behind the enchant API. This may include installing a particular 
+      dictionary.
+    required: false
+    default: "hunspell hunspell-en-gb"
 runs:
   using: composite
   steps:
-  - run: |
+  - name: Install spell checker
+    shell: bash
+    run: |
+      sudo apt-get update
+      sudo apt-get -o Dpkg::Use-Pty=0 install --fix-missing enchant-2 $SPELL_PACKAGES
+    env:
+      SPELL_PACKAGES: ${{ inputs.spell-checker-implementation }}
+  - name: Install Python tooling
+    shell: bash
+    run: |
       python -m pip install --upgrade setuptools wheel
       python -m pip install pip
-      pip install flake8 "pylint $PYLINT_VERSION"
+      pip install flake8 "pylint $PYLINT_VERSION" pyenchant
       if [ $DO_COVERAGE = "true" ]; then
         pip install "coverage $COVERAGE_VERSION" coveralls
       fi
-    shell: bash
     env:
       PYLINT_VERSION: ${{ inputs.pylint-version }}
       DO_COVERAGE: ${{ inputs.coverage == 'true' }}

--- a/actions/python-tools/action.yml
+++ b/actions/python-tools/action.yml
@@ -39,28 +39,19 @@ inputs:
 runs:
   using: composite
   steps:
-  - name: Dependency preconfigure
-    shell: bash
-    run: |
-      echo "::group::Doing dependency preconfiguration"
-      sudo apt-get update
-      echo "::endgroup::"
   - name: Install spell checker
     shell: bash
-    run: |
-      echo "::group::Installing spell checker"
-      sudo apt-get -o Dpkg::Use-Pty=0 install --fix-missing enchant-2 $SPELL_PACKAGES
-      echo "::endgroup::"
+    run: source $SUPPORT_DIR/setup-spell.bash
     env:
       SPELL_PACKAGES: ${{ inputs.spell-checker-implementation }}
+      SUPPORT_DIR: ${{ github.action_path }}
   - name: Upgrade Python baseline tooling
     shell: bash
-    run: |
-      echo "::group::Upgrading Python baseline tooling"
-      python -m pip install --upgrade setuptools wheel
-      python -m pip install pip
-      echo "::endgroup::"
-  - name: Install Python tooling
+    run: python -m pip install --upgrade setuptools wheel
+  - name: Ensure correct version of pip
+    shell: bash
+    run: python -m pip install pip
+  - name: Install extended Python tooling
     shell: bash
     run: |
       pip install flake8 "pylint $PYLINT_VERSION" pyenchant

--- a/actions/python-tools/setup-spell.bash
+++ b/actions/python-tools/setup-spell.bash
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Copyright (c) 2023 The University of Manchester
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+echo "::group::Doing dependency preconfiguration"
+sudo apt-get update
+echo "::endgroup::"
+
+echo "::group::Installing spell checker"
+sudo apt-get -o Dpkg::Use-Pty=0 install --fix-missing enchant-2 $SPELL_PACKAGES
+echo "::endgroup::"

--- a/actions/run-install/action.yml
+++ b/actions/run-install/action.yml
@@ -14,6 +14,10 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 name: "Install Python Package from Source"
+description: >
+  Installs a (presumably SpiNNaker-related) Python package from a checkout of 
+  the source tree.
+  Should be run with the working directory at the root of the checkout.
 inputs:
   extras_require:
     description: Which extras_require to included from setup.cfg

--- a/actions/run-setup/action.yml
+++ b/actions/run-setup/action.yml
@@ -14,11 +14,16 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 name: "Install Python Package from Source"
+description: >
+  Installs a (presumably SpiNNaker-related) Python package from a checkout of 
+  the source tree.
+  Should be run with the working directory at the root of the checkout.
+  Requires the existance of a setup.py in the working directory.
 inputs:
   preinstall:
     description: Whether to run the requirements.txt ahead of the main install
     required: false
-    default: false
+    default: "false"
   requirements-path:
     description: The name of the requirements.txt
     required: false
@@ -26,7 +31,7 @@ inputs:
   test-requirements:
     description: Whether to run the requirements-test.txt after the main install
     required: false
-    default: true
+    default: "true"
   test-requirements-path:
     description: The name of the requirements-test.txt
     required: false

--- a/actions/sphinx/action.yml
+++ b/actions/sphinx/action.yml
@@ -30,7 +30,7 @@ inputs:
   blessed-version:
     description: What version of Python will actually have the doc build done
     required: false
-    default: 3.8
+    default: "3.8"
 runs:
   using: composite
   steps:

--- a/actions/validate-xml/action.yml
+++ b/actions/validate-xml/action.yml
@@ -14,6 +14,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 name: "Validate SpiNNaker XML"
+description: >
+  Validate some XML files against one of the schemas known to this action.
 inputs:
   base-path:
     description: 


### PR DESCRIPTION
This adds support for spell checking our Python docstrings (see https://github.com/SpiNNakerManchester/SpiNNUtils/pull/225).

To enable, add `language: en_GB` to the invocation of the `pylint` action (via `with`). You may also define a dictionary of words to be ignored; this is a text file of words, one per line (blank lines and `#`-started lines are ignored). The dictionary defaults to being called `.pylint_dict.txt` in the root of the project, but you can override this with `dictionary: other_file.txt`.

You may also need to add `C0402,C0403` to the `enable` line in your `.pylintrc`.