### PR TITLE
Install a newer version of coverage by default

### DIFF
--- a/actions/python-tools/action.yml
+++ b/actions/python-tools/action.yml
@@ -28,7 +28,7 @@ inputs:
   coverage-version:
     description: The version of coverage desired
     required: false
-    default: ">= 4.4, < 5.0"
+    default: ">= 6.0"
   spell-checker-implementation:
     description: >
       The packages required for the implementation of the spell checker. These


### PR DESCRIPTION
The install of the coverage package was blowing up in metadata generation.