### PR TITLE
indirect dieghernan/cff-validator@main

### DIFF
--- a/actions/cff-validator/action.yml
+++ b/actions/cff-validator/action.yml
@@ -1,0 +1,24 @@
+# Copyright (c) 2023 The University of Manchester
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: "Run cff-validator"
+description: |
+  Runs dieghernan/cff-validator@main
+  Note Does it indirectly so it is easier to enable or disable as needed,
+  currently disabled due to https://github.com/dieghernan/cff-validator/issues/10
+runs:
+  using: composite
+  steps:
+    - name: Validate CITATION.cff
+      uses: dieghernan/cff-validator@main


### PR DESCRIPTION
Due to https://github.com/dieghernan/cff-validator/issues/10 we need to disable dieghernan/cff-validator

This pr allows to run it indectly via an action we control.

We can then turn it off and later back on globally.

