### PR TITLE
Set dns server LINUX

### DIFF
--- a/actions/prepare/action.yml
+++ b/actions/prepare/action.yml
@@ -122,3 +122,12 @@ runs:
         echo 'spalloc_server = https://spinnaker.cs.man.ac.uk/spalloc/' >> ~/.${{ inputs.cfg_file }}.cfg
         echo 'spalloc_port = 22244' >> ~/.${{ inputs.cfg_file }}.cfg
         echo 'version = 5' >> ~/.${{ inputs.cfg_file }}.cfg
+
+    - name: Set dns server LINUX
+      shell: bash
+      if: runner.os == 'Linux'
+      run: |
+        sudo sed -i 's/#DNS=/DNS=8.8.8.8 8.8.4.4/g' /etc/systemd/resolved.conf
+        sudo systemctl daemon-reload
+        sudo systemctl restart systemd-networkd
+        sudo systemctl restart systemd-resolved


### PR DESCRIPTION
hack for https://github.com/SpiNNakerManchester/SpiNNMan/issues/414

Linux goes green with this hack.
same as: https://github.com/SpiNNakerManchester/JavaSpiNNaker/pull/1170

Windows 
- has not yet failed
- uses an idirect DNS https://learn.microsoft.com/en-us/azure/virtual-network/what-is-ip-address-168-63-129-16

Macos
- fails most runs
- normal dns checks show it is already suing 8,8,8,8
- Needs more work but so far unable to work out how!

tested by:
https://github.com/SpiNNakerManchester/sPyNNaker/actions/runs/10593826127