### PR TITLE
Test 3.14 and remove special 3.13 prepare

### DIFF
--- a/.github/workflows/python_checks.yml
+++ b/.github/workflows/python_checks.yml
@@ -218,8 +218,8 @@ jobs:
       matrix:
         include:
           # prereleases
-          # - runner: ubuntu-latest
-          #  python-version: "3.14"
+          - runner: ubuntu-latest
+            python-version: "3.14"
 
           - runner: ubuntu-latest
             python-version: "3.13"
@@ -240,23 +240,10 @@ jobs:
     timeout-minutes: 20
     steps:
     - name: Prepare
-      if: ${{ matrix.python-version != '3.13' }}
       #if: ${{ matrix.python-version != env.PRERELEASE || inputs.check-prereleases == 'true' }}
       uses: SpiNNakerManchester/SupportScripts/actions/prepare@main
       with:
         python-version: ${{ matrix.python-version }}
-        install-dependencies: ${{ inputs.dependencies }}
-        install-module: ${{ inputs.install-module }}
-        install-check-tools: true
-        ubuntu-packages: ${{ inputs.ubuntu-packages }}
-        cfg-file: ${{ inputs.cfg-file }}
-        pip-installs: ${{ inputs.pip-installs }}
-
-    - name: Prepare 3.13.5
-      if: ${{ matrix.python-version == '3.13' }}
-      uses: SpiNNakerManchester/SupportScripts/actions/prepare@main
-      with:
-        python-version: 3.13
         install-dependencies: ${{ inputs.dependencies }}
         install-module: ${{ inputs.install-module }}
         install-check-tools: true

--- a/.github/workflows/python_checks.yml
+++ b/.github/workflows/python_checks.yml
@@ -135,7 +135,7 @@ on:
 
 
 env:
-  PRERELEASE: "3.14"
+  PRERELEASE: "3.15"
 
 jobs:
   validate:

--- a/.github/workflows/python_checks.yml
+++ b/.github/workflows/python_checks.yml
@@ -264,7 +264,8 @@ jobs:
       run: flake8 ${{ inputs.flake8-packages }}
 
     - name: Lint with pylint
-      if: ${{ matrix.python-version != env.PRERELEASE || inputs.check-prereleases == 'true' }}
+      if: ${{ matrix.python-version != '3.14' }}
+      #if: ${{ matrix.python-version != env.PRERELEASE || inputs.check-prereleases == 'true' }}
       uses: SpiNNakerManchester/SupportScripts/actions/pylint@main
       with:
         package: ${{ inputs.pylint-packages }}


### PR DESCRIPTION
The special prepare stage that I thought was capping python to 3.13.5 actually was not!
So we where using 3.13.7

fixes https://github.com/SpiNNakerManchester/SupportScripts/issues/88

Also added python 3.14 testing.

Tested with https://github.com/SpiNNakerManchester/SpiNNMan/actions
where pylint failed so temporarily disabled for 3.14

As 3.14 is not yet a branch protection rule ok to merge this without testing on all repositories

Note. I used the prepare 3.13 stage to test with specifically 3.13.6 and that fails
